### PR TITLE
Fix CVE-2025-26646: Update Nuke.Common to 9.0.4 and Microsoft.Build.Tasks.Core to 17.14.8

### DIFF
--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,7 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="8.1.4" />
+    <PackageReference Include="Nuke.Common" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.14.8" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION

This PR addresses the high-severity vulnerability CVE-2025-26646 by:

1. Updating Nuke.Common from 8.1.4 to 9.0.4
2. Adding a direct dependency on Microsoft.Build.Tasks.Core 17.14.8

The vulnerability is related to external control of file name or path in .NET, Visual Studio, and Build Tools for Visual Studio, with a CVSS score of 8.0. The fix ensures we use the patched version of Microsoft.Build.Tasks.Core that resolves this security issue.
